### PR TITLE
CLI enhancements

### DIFF
--- a/mipc_camera_client/cli.py
+++ b/mipc_camera_client/cli.py
@@ -46,6 +46,8 @@ def snapshot(c: MipcCameraClient, filename: Optional[str]) -> None:
     if out_path:
         out_path.write_bytes(jpeg)
     LOGGER.info(f"saved {len(jpeg)} bytes to {out_path or 'stdout'}")
+    if out_path:
+        print(out_path)
 
 
 def ptz_handler(
@@ -71,6 +73,12 @@ def parse_args() -> argparse.Namespace:
         default=os.getenv("CAMERA_USER"),
         help="Camera username (from the web interface), uses CAMERA_USER env var if not supplied. Set CAMERA_PASSWORD for password.",
     )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        default=False,
+        help="Silence all output except for the snapshot filename or stream URL")
     subparsers = parser.add_subparsers(
         title="commands",
         description="Available commands",
@@ -133,6 +141,8 @@ def main():
         level="INFO",
     )
     args = parse_args()
+    if args.quiet:
+        logging.getLogger().setLevel(logging.CRITICAL)
     LOGGER.info(f"Logging into {args.host} as {args.user}")
     c = MipcCameraClient(args.host)
     c.login(args.user, os.environ["CAMERA_PASSWORD"])

--- a/mipc_camera_client/cli.py
+++ b/mipc_camera_client/cli.py
@@ -11,7 +11,7 @@ import inspect
 LOGGER = logging.getLogger("mipc_camera_client")
 
 
-def stream_url(c: MipcCameraClient) -> str:
+def print_stream_url(c: MipcCameraClient) -> None:
     LOGGER.info("Getting RTMP stream URL")
     print(c.get_rtmp_stream())
 
@@ -91,7 +91,7 @@ def parse_args() -> argparse.Namespace:
         "stream",
         help="get RTMP stream URL",
     )
-    stream_parser.set_defaults(handler=stream_url)
+    stream_parser.set_defaults(handler=print_stream_url)
 
     ptz_parser = subparsers.add_parser("ptz", help="control pan/tilt/zoom")
 

--- a/mipc_camera_client/cli.py
+++ b/mipc_camera_client/cli.py
@@ -143,6 +143,9 @@ def main():
     args = parse_args()
     if args.quiet:
         logging.getLogger().setLevel(logging.CRITICAL)
+    if "CAMERA_PASSWORD" not in os.environ:
+        print("Error: environment variable CAMERA_PASSWORD not set", file=sys.stderr)
+        sys.exit(2)
     LOGGER.info(f"Logging into {args.host} as {args.user}")
     c = MipcCameraClient(args.host)
     c.login(args.user, os.environ["CAMERA_PASSWORD"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 keywords = ["webcam", "mipc", "rtsp", "ip camera", "cli", "command line interface", "ptz"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 requests = "^2.31.0"
 json5 = "^0.9.14"
 pycryptodome = "^3.18.0"


### PR DESCRIPTION
Please consider merging these commits, which are minor fixes and enhancements.

Note that the `--quiet` is for scripting with less line noise. For example, I have:

```bash
CAMERA_PASSWORD=$(op read "op://Shared/IP Camera/password")  # 1password
STREAM_URL=$(CAMERA_PASSWORD=$CAMERA_PASSWORD poetry run mipc_camera_client --host 192.168.99.221 --user 1jfiegbqwpjre --quiet stream)
/Applications/VLC.app/Contents/MacOS/VLC --no-drop-late-frames $STREAM_URL &
```

Manually tested all three commands with and without `-q`.

Thanks for this very helpful library and tool. I know the pain of interpreting and cleanly reimplementing extracted/minified code.